### PR TITLE
Use the title set in the CMS

### DIFF
--- a/src/SearchService.php
+++ b/src/SearchService.php
@@ -116,13 +116,10 @@ class SearchService
      */
     private function getFileFromURL(string $url): ?File
     {
-        //this also removes 'assets' from the path, since File::find does not expect it to be there
-        $parts =   array_filter(preg_split("#[/\\\\]+#", $url ?? '') ?? []);
-        unset($parts[0]);
-        unset($parts[1]);
-        unset($parts[2]);
-        $filePath = implode('/', $parts);
+        $path = parse_url($url)['path'];
+        //removes 'assets', since File::find does not expect it to be there
+        $path = str_replace(ASSETS_DIR . '/', '', $path);
 
-        return File::find($filePath);
+        return File::find($path);
     }
 }

--- a/src/SearchService.php
+++ b/src/SearchService.php
@@ -118,7 +118,7 @@ class SearchService
     {
         $path = parse_url($url)['path'];
         //removes 'assets', since File::find does not expect it to be there
-        $path = str_replace(ASSETS_DIR . '/', '', $path);
+        $path = preg_replace('/' . ASSETS_DIR . '\//', '', $path, 1);
 
         return File::find($path);
     }

--- a/src/SearchService.php
+++ b/src/SearchService.php
@@ -2,6 +2,7 @@
 
 namespace Madmatt\Funnelback;
 
+use SilverStripe\Assets\File;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\ORM\ArrayList;
@@ -42,7 +43,12 @@ class SearchService
 
                 // If the file is anything but HTML, then it's downloadable. Ensure we append the file type and file size to the end
                 if ($fileType != self::FILE_TYPE_HTML) {
-                    $title = $this->formatFileTitle($title, $fileType, $result['fileSize']);
+                    $file = $this->getFileFromURL($result['indexUrl']);
+                    $title = $this->formatFileTitle(
+                        !$file ? 'File Not Found' : $file->Title,
+                        $fileType,
+                        $result['fileSize']
+                    );
                 }
 
                 $list->push([
@@ -98,5 +104,24 @@ class SearchService
         $fileSizeBytes /= pow(1024, $prefixIndex);
 
         return round($fileSizeBytes, 0) . $units[$prefixIndex];
+    }
+
+    /**
+     * The functions takes in a full url (including protocol) and tries to find a
+     * matching file in the assets folder
+     *
+     *
+     * @param string $url
+     * @return File|null
+     */
+    private function getFileFromURL(string $url): ?File
+    {
+        $parts =   array_filter(preg_split("#[/\\\\]+#", $url ?? '') ?? []);
+        unset($parts[0]);
+        unset($parts[1]);
+        unset($parts[2]);
+        $filePath = implode('/', $parts);
+
+        return File::find($filePath);
     }
 }

--- a/src/SearchService.php
+++ b/src/SearchService.php
@@ -18,7 +18,7 @@ class SearchService
 
     public const FILE_TYPE_HTML = 'html';
 
-    public function search(string $keyword = "", int $start = 0, int $limit = 10): ?PaginatedList
+    public function search(?string $keyword = "", ?int $start = 0, ?int $limit = 10): ?PaginatedList
     {
         // Short circuit - if no keyword is entered, don't bother searching
         if (!$keyword) {

--- a/src/SearchService.php
+++ b/src/SearchService.php
@@ -45,7 +45,7 @@ class SearchService
                 if ($fileType != self::FILE_TYPE_HTML) {
                     $file = $this->getFileFromURL($result['indexUrl']);
                     $title = $this->formatFileTitle(
-                        !$file ? 'File Not Found' : $file->Title,
+                        $file ? $file->Title : 'File Not Found',
                         $fileType,
                         $result['fileSize']
                     );
@@ -116,6 +116,7 @@ class SearchService
      */
     private function getFileFromURL(string $url): ?File
     {
+        //this also removes 'assets' from the path, since File::find does not expect it to be there
         $parts =   array_filter(preg_split("#[/\\\\]+#", $url ?? '') ?? []);
         unset($parts[0]);
         unset($parts[1]);


### PR DESCRIPTION
Use the file title set in the CMS instead of default funnel back behaviour. This will try to find the file in the database and use the title set there.